### PR TITLE
update a snapshot from 3224 to 3010 for pass the test

### DIFF
--- a/src/__snapshots__/signpdf.test.js.snap
+++ b/src/__snapshots__/signpdf.test.js.snap
@@ -10,4 +10,4 @@ exports[`Test signing expects PDF to be Buffer 1`] = `"PDF expected as Buffer."`
 
 exports[`Test signing expects PDF to contain a ByteRange placeholder 1`] = `"Could not find ByteRange placeholder: /ByteRange [0 /********** /********** /**********]"`;
 
-exports[`Test signing expects a reasonably sized placeholder 1`] = `"Signature exceeds placeholder length: 3224 > 4"`;
+exports[`Test signing expects a reasonably sized placeholder 1`] = `"Signature exceeds placeholder length: 3010 > 4"`;


### PR DESCRIPTION
This is necessary, because you removed authenticated attributes:

[https://github.com/vbuch/node-signpdf/pull/72/commits/1f4f9bbc8d935c1f1609a98a70be8fc4f385776d#diff-6ef7a21d56786f69da7e937c142eaa3aL137](url)

So the length of signature is smaller.

